### PR TITLE
Add Timer name rename API and fix inactive timers coming as completed

### DIFF
--- a/chrona-backend/countdown/models.py
+++ b/chrona-backend/countdown/models.py
@@ -22,7 +22,7 @@ class Timers(Model):
     name = EncryptedCharField(max_length=255)
     duration_seconds = models.PositiveIntegerField(default=0)
     remaining_duration_seconds = models.PositiveIntegerField(default=0)
-    status = models.CharField(max_length=10, choices=STATUS_CHOICES)
+    status = models.CharField(max_length=10, choices=STATUS_CHOICES, default='inactive')
     is_recurring = models.BooleanField(default=False)
     start_at = models.DateTimeField(blank=True, null=True)
     paused_at = models.DateTimeField(blank=True, null=True)

--- a/chrona-backend/countdown/serializers.py
+++ b/chrona-backend/countdown/serializers.py
@@ -1,3 +1,4 @@
+from django.core.validators import RegexValidator
 from django.utils import timezone
 from rest_framework import serializers
 
@@ -110,8 +111,14 @@ class TimerSerializer(TimerValidator, serializers.ModelSerializer):
     for handling specific timer lifecycle events (start, pause, reset, complete).
     """
 
-    name = serializers.CharField(required=True)
-    timestamp = serializers.DateTimeField(required=True, write_only=True)
+    name = serializers.CharField(
+        max_length=100,
+        validators=[
+            # only letters, numbers, spaces, hyphens and underscores
+            RegexValidator(r'^[\w\s-]+$', 'Name contains invalid characters.')
+        ]
+    )
+    timestamp = serializers.DateTimeField(required=True, write_only=True, allow_null=True)
     status = serializers.CharField(read_only=True)
 
     class Meta:
@@ -128,17 +135,15 @@ class TimerSerializer(TimerValidator, serializers.ModelSerializer):
         Returns:
             Timers: Newly created timer instance.
         """
-        if validated_data.get('name') is None:
-            raise serializers.ValidationError("Timer name is required.")
         timestamp = validated_data.pop('timestamp')
 
         validated_data.update({
-            'status': 'active',
-            'paused_at': None,
-            'resumed_at': timestamp,
-            'start_at': timestamp,
-            'user_id': self.context['request'].user,
-            'remaining_duration_seconds': validated_data.get('duration_seconds')
+        #     'status': 'active',
+        #     'paused_at': None,
+        #     'resumed_at': timestamp,
+        #     'start_at': timestamp,
+              'user_id': self.context['request'].user,
+        #     'remaining_duration_seconds': validated_data.get('duration_seconds')
         })
         return super().create(validated_data)
 
@@ -154,7 +159,7 @@ class TimerSerializer(TimerValidator, serializers.ModelSerializer):
         Returns:
             dict: Serialized timer data for API response.
         """
-        if not instance.paused_at and instance.resumed_at:
+        if instance.status != "inactive" and not instance.paused_at and instance.resumed_at:
             elapsed = (timezone.now() - instance.resumed_at).total_seconds()
             instance.remaining_duration_seconds = max(0, instance.remaining_duration_seconds - elapsed)
 

--- a/chrona-backend/countdown/views.py
+++ b/chrona-backend/countdown/views.py
@@ -1,5 +1,5 @@
 import logging
-
+from rest_framework.response import Response
 from rest_framework.decorators import action
 
 from countdown.serializers import TimerSerializer, Timers
@@ -57,3 +57,9 @@ class TimerViewSet(BaseModelViewSet):
         context = super().get_serializer_context()
         context['endpoint'] = self.request.path
         return context
+
+    @action(methods=['patch'], detail=True)
+    def rename(self, request, **kwargs):
+        data = self.partial_update(request, **kwargs)
+        return Response({"data": {"name": data.data['name']}, "message": "Timer renamed successfully."}, status=200)
+


### PR DESCRIPTION
# 📥 Pull Request

Thank you for contributing to Chrona!  
Please fill out the details below so we can review and integrate smoothly.

---

## 📌 Summary

<!-- Describe the purpose of this PR in one or two sentences. -->

---

## ✨ What’s New / Changed

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD
- [ ] Other (please describe):

**Summary of Changes:**

<!--
Example:
- Added Timer v3 API
- Refactored logging service handlers
- Fixed countdown timer desync issue
-->

---

## 🛑 Breaking Changes

- [ ] YES (describe below)
- [ ] NO

**If yes, describe:**

<!--
Example:
- Deprecated `/v1/timer` endpoints in favor of `/v3/timer`
-->

---

## 📈 Testing

- [ ] Locally tested (Docker / Poetry)
- [ ] API validated
- [ ] Observability (Prometheus, Logs, Grafana)
- [ ] CI/CD passed

**Notes (optional):**

<!--
Describe any testing steps, special considerations, or followups.
-->

---

## 📚 Documentation

- [ ] CHANGELOG.md updated (If applicable)
- [ ] RELEASE_NOTES.md updated (If applicable)
- [ ] Docs/Comments added (If applicable)

---

## 📌 Notes to Reviewers (optional)

<!--
Any special instructions, blockers, or points for discussion.
-->

